### PR TITLE
Add `select` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,6 @@
 - `:ColorschemeCycle next`: Use the next available colorscheme
 - `:ColorschemeCycle prev`: use the previous available colorscheme
 
-### Keymapping
-
-If you're quickly previewing several colorschemes, using a keymap will likely be easier
-than calling the `:ColorschemeCycle` command repeatedly. For example, the following
-examples will allow you to cycle to the next and previous colorscheme with
-`Ctrl` + `c` + `↓` and `Ctrl` + `c` + `↑`.
-
-```lua
--- init.lua
-vim.keymap.set('n', '<C-c><down>', '<cmd>ColorschemeCycle next<cr>')
-vim.keymap.set('n', '<C-c><up>', '<cmd>ColorschemeCycle prev<cr>')
-```
-
-```vim
-" init.vim
-nnoremap <C-c><down> :ColorschemeCycle next<CR>
-nnoremap <C-c><up> :ColorschemeCycle prev<CR>
-```
-
 ## Installation
 
 With [lazy.nvim][lazy-nvim]:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Usage
 
-- `:ColorschemeCycle` / `:ColorschemeCycle next`: Use the next available colorscheme
+- `:ColorschemeCycle` / `:ColorschemeCycle select`: Open a menu to preview and select a colorscheme
+- `:ColorschemeCycle next`: Use the next available colorscheme
 - `:ColorschemeCycle prev`: use the previous available colorscheme
 
 ### Keymapping

--- a/lazy.lua
+++ b/lazy.lua
@@ -1,0 +1,3 @@
+return {
+  { "MunifTanjim/nui.nvim", lazy = true },
+}

--- a/plugin/colorschemecycle.lua
+++ b/plugin/colorschemecycle.lua
@@ -20,13 +20,72 @@ local function decrement_index()
   index = ((index - 2) % #colors) + 1
 end
 
+local function show_menu()
+  local previous_color = vim.g.colors_name
+  local Menu = require("nui.menu")
+  local event = require("nui.utils.autocmd").event
+
+  local popup_options = {
+    position = "90%",
+    size = {
+      width = 25,
+      height = 10,
+    },
+    border = {
+      style = "single",
+      text = {
+        top = "Choose a colorscheme",
+        top_align = "center",
+      },
+    },
+    win_options = {
+      winblend = 10,
+      winhighlight = "Normal:Normal",
+    }
+  }
+  local lines = {}
+  for i, color in ipairs(colors) do
+    lines[i] = Menu.item(color)
+  end
+  local menu = Menu(popup_options, {
+    lines = lines,
+    max_width = 20,
+    keymap = {
+      focus_next = { "j", "<Down>", "<Tab>" },
+      focus_prev = { "k", "<Up>", "<S-Tab>" },
+      close = { "<Esc>", "<C-c>" },
+      submit = { "<CR>", "<Space>" },
+    },
+    on_close = function()
+      vim.cmd.colorscheme(previous_color)
+    end,
+    on_change = function(item, menu)
+      vim.cmd.colorscheme(item.text)
+    end,
+    on_submit = function(item)
+      local selected = nil
+      index, selected = selected_color()
+      print(selected)
+    end
+  })
+
+  menu:mount()
+
+  menu:on(event.BufLeave, function()
+    menu:unmount()
+  end)
+end
+
 local function cycle_colorscheme(opts)
   index, _ = selected_color()
-  local direction = opts.fargs[1] or 'next'
+  local direction = opts.fargs[1] or 'select'
   if direction == 'next' then
     increment_index()
   elseif direction == 'prev' then
     decrement_index()
+  elseif direction == 'select' then
+    show_menu()
+    return
   end
   local selected = colors[index]
   vim.cmd.colorscheme(selected)
@@ -34,7 +93,7 @@ local function cycle_colorscheme(opts)
 end
 
 local function completions(ArgLead, CmdLine, CursorPos)
-  return { "next", "prev" }
+  return { "next", "prev", "select" }
 end
 
 vim.api.nvim_create_user_command('ColorschemeCycle', cycle_colorscheme, {


### PR DESCRIPTION
This option brings up a menu to select the new colorscheme, setting the colorscheme on change to allow for previewing. It "commits" the change when the user selects a colorscheme, and reverts the change if the user cancels.